### PR TITLE
Update connection name in function.json

### DIFF
--- a/TeamsWebhook/function.json
+++ b/TeamsWebhook/function.json
@@ -11,7 +11,7 @@
       },
       {
         "type": "serviceBus",
-        "connection": "poshbot-teams_RootManageSharedAccessKey_SERVICEBUS",
+        "connection": "SB_CONNECTION",
         "name": "outputSbMsg",
         "queueName": "messages",
         "accessRights": "Send",


### PR DESCRIPTION
Teams backend documentation and setup uses **SB_CONNECTION** for the connection string name, rather than **poshbot-teams_RootManageSharedAccessKey_SERVICEBUS**

Resolves function app error: 
Microsoft Azure WebJobs SDK ServiceBus connection string 'poshbot-teams_RootManageSharedAccessKey_SERVICEBUS' is missing or empty