### PR TITLE
Updated to v2 Runtime

### DIFF
--- a/TeamsWebhook/function.json
+++ b/TeamsWebhook/function.json
@@ -1,22 +1,20 @@
 {
-    "bindings": [
-      {
-        "name": "req",
-        "type": "httpTrigger",
-        "direction": "in",
-        "methods": [
-          "post"
-        ],
-        "authLevel": "function"
-      },
-      {
-        "type": "serviceBus",
-        "connection": "SB_CONNECTION",
-        "name": "outputSbMsg",
-        "queueName": "messages",
-        "accessRights": "Send",
-        "direction": "out"
-      }
-    ],
-    "disabled": false
-  }
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "Request",
+      "methods": [
+        "post"
+      ]
+    },
+    {
+      "type": "serviceBus",
+      "direction": "out",
+      "name": "outputSbMsg",
+      "queueName": "messages",
+      "connection": "SB_CONNECTION"
+    }
+  ]
+}

--- a/TeamsWebhook/run.ps1
+++ b/TeamsWebhook/run.ps1
@@ -1,3 +1,7 @@
-$request = Get-Content $req -Raw
+param (
+    $Request,
+    $TriggerMetadata
+)
 
-Out-File -Encoding Ascii -FilePath $outputSbMsg -inputObject $request
+# Associate values to output bindings by calling 'Push-OutputBinding'.
+Push-OutputBinding -Name outputSbMsg -Value $Request.body

--- a/host.json
+++ b/host.json
@@ -1,1 +1,7 @@
-{}
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[1.*, 2.0.0)"
+  }
+}


### PR DESCRIPTION
Updated to use the newer syntax and bindings.

host.json updates ensure the extension bindings are installed so it doesn't have to be done manually. Docs are a little ambiguous on how to achieve this otherwise.